### PR TITLE
Dependency graphs in mermaid

### DIFF
--- a/graphs/cognito-trigger-graph.md
+++ b/graphs/cognito-trigger-graph.md
@@ -1,0 +1,24 @@
+## Graph with Cognito Trigger
+
+Showing cyclic dependency between Cognito, Cognito Trigger and Customer and User Service.
+
+This is the current solution.
+
+```mermaid
+graph TD
+    PS[Publication Service] --> CD[Custom Domain]
+    CS[Customer Sevice] --> CD
+    US[User Service] --> CD
+    CT[Cognito Post-Auth Trigger] --> CD
+    CS --> CDB[(Customer DB)]
+    US --> UDB[(User DB)]
+    DNS[Hosted Zone] --> CERT[Certificate]
+    CD --> DNS
+    COG[Cognito] --> CT
+    PS --> COG
+    US --> COG
+    CS --> COG
+    CT --> CS
+    CT --> US
+    PS --> EB[Event Bus]
+```

--- a/graphs/external-api-graph.md
+++ b/graphs/external-api-graph.md
@@ -1,0 +1,25 @@
+## Graph with separate web API and internal API
+
+Showing possible new dependency graph where User API (web API) is separate from User Service (internal API).
+
+Possible new solution.
+
+```mermaid
+graph TD
+    PS[Publication API] --> CD[Custom Domain]
+    CS[Customer API] --> CD
+    US[User API] --> CD
+    CSI --> CDB[(Customer DB)]
+    USI --> UDB[(User DB)]
+    DNS[Hosted Zone] --> CERT[Certificate]
+    CD --> DNS
+    COG[Cognito] --> CT[Cognito Post-Auth Trigger]
+    PS --> COG
+    US --> COG
+    CS --> COG
+    CS --> CSI
+    US --> USI
+    CT --> CSI[Customer Service]
+    CT --> USI[User Service]
+    PS --> EB[Event Bus]
+```

--- a/graphs/no-cognito-trigger-graph.md
+++ b/graphs/no-cognito-trigger-graph.md
@@ -1,0 +1,22 @@
+## Graph with Cognito without trigger
+
+Showing possible new dependency graph where Cognito is not using a trigger to create the access token. Requires the client
+ to possible look up extra claims from the /userinfo endpoint or similar.
+
+Possible new solution.
+
+```mermaid
+graph TD
+    PS[Publication Service] --> CD[Custom Domain]
+    CS[Customer Service] --> CD
+    US[User Service] --> CD
+    CS --> CDB[(Customer DB)]
+    US --> UDB[(User DB)]
+    DNS[Hosted Zone] --> CERT[Certificate]
+    CD --> DNS
+    COG[Cognito]
+    PS --> COG
+    US --> COG
+    CS --> COG
+    PS --> EB[Event Bus]
+```


### PR DESCRIPTION
To be used as draft for changes to the C4 model.

Enable diagram support﻿ in IntelliJ

    In the Settings/Preferences dialog Ctrl+Alt+S, select Languages & Frameworks | Markdown.

    Enable Mermaid under Markdown Extensions.

    After IntelliJ IDEA downloads the relevant extensions, click OK to apply the changes.